### PR TITLE
Writing suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ As a reporter your world is full of data. And those data are full of problems. T
 
 Most of these problems can be solved. Some of them can't be solved and that means you should not use the data. Others can't be solved, but with precautions you can continue using the data. In order to allow for these ambiguities, this guide is organized by who is best equipped to solve the problem: you, your source, an expert, etc. In the description of each problem you may also find suggestions for what to do if that person can't help you.
 
-You can not possibly review every dataset you encounter with for all of these problems. If you try to do that you will never get anything published. However, by familiarizing yourself with the kinds of issues you are likely to encounter you will have a better chance of identifying an issue before it causes you to make a mistake.
+You cannot possibly review every dataset you encounter for all of these problems. If you try to do that, you will never get anything published. However, by familiarizing yourself with the kinds of issues you are likely to encounter, you will have a better chance of identifying an issue before it causes you to make a mistake.
 
 If you have questions about this guide please email [Chris](mailto:c@qz.com). Good luck!
 
@@ -73,11 +73,11 @@ If you have questions about this guide please email [Chris](mailto:c@qz.com). Go
 
 Beware blank or "null" values in any dataset unless you are certain you know what they mean. If the data are annual, was the value for that year never collected? If it is a survey, did a respondent refuse to answer the question?
 
-Anytime you're working with data that has missing values you should ask yourself: "Do I know what the absence of this data means?" If the answer is no, you should ask your source.
+Any time you're working with data that has missing values you should ask yourself: "Do I know what the absence of this data means?" If the answer is no, you should ask your source.
 
 ### Zeros replace missing values
 
-Worse than missing values is when an arbitrary value is used instead. This can be the result of a human not thinking through the implications or it can happen as the result of automated processes that simply don't know how to handle null values. In any case if you see zeros in a series of numbers you should ask yourself if that values is really the number `0` or if it instead means "nothing". If you aren't sure, ask your source.
+Worse than missing values is when an arbitrary value is used instead. This can be the result of a human not thinking through the implications, or it can happen as the result of automated processes that simply don't know how to handle null values. In any case, if you see a zero in a series of numbers you should ask yourself if that value is really the number `0` or if it instead means "nothing". If you aren't sure, ask your source.
 
 See also:
 
@@ -85,15 +85,15 @@ See also:
 
 ### Data are missing you know should be there
 
-Sometimes data are missing and you can't tell from the dataset itself, but you can still know because you know what the data purports to be about. If you have a dataset covering the United States then you can check to ensure all 50 states represented. (And don't forget about [the territories](https://en.wikipedia.org/wiki/Territories_of_the_United_States)—50 isn't the right number if the dataset includes Puerto Rico.) If you're dealing with a dataset of baseball players make sure it has the number of teams you expect. Verify that a few players who you know are included. Trust your intuition if something seems to missing and double-check with your source. The universe of your data might be smaller than you think.
+Sometimes data are missing and you can't tell from the dataset itself, but you can still know because you know what the data purports to be about. If you have a dataset covering the United States then you can check to ensure all 50 states represented. (And don't forget about [the territories](https://en.wikipedia.org/wiki/Territories_of_the_United_States)—50 isn't the right number if the dataset includes Puerto Rico.) If you're dealing with a dataset of baseball players make sure it has the number of teams you expect. Verify that a few players whom you know are included. Trust your intuition if something seems to missing and double-check with your source. The universe of your data might be smaller than you think.
 
 ### Rows or values are duplicated
 
-If the same row appears in your dataset twice you should find out why. Sometimes it need not be a whole row. Some campaign finance data includes "amendments" that use the same unique identifiers as the original transaction. If you didn't know that then any calculations you did with the data would be wrong. If something seems like it should be unique verify that it is. If you discover that it isn't, ask your source why.
+If the same row appears in your dataset twice you should find out why. Sometimes it need not be a whole row. Some campaign finance data includes "amendments" that use the same unique identifiers as the original transaction. If you didn't know that, then any calculations you did with the data would be wrong. If something seems like it should be unique, verify that it is. If you discover that it isn't, ask your source why.
 
 ### Spelling is inconsistent
 
-Spelling is one of the most obvious ways of telling if data has been compiled by hand. Don't just look at people's names—those are often the hardest place to detect spelling errors. Instead look for places where city names or states aren't consistent. (`Los Angelos` is one very common mistake.) If you find those, you can be pretty sure the data was compiled or edited by hand and that is always a reason to be skeptical of it. Data that has been edited by hand is the most likely to have mistakes. This doesn't mean you shouldn't use it but you may need to manually correct those mistakes or otherwise account for them in your reporting.
+Spelling is one of the most obvious ways of telling if data has been compiled by hand. Don't just look at people's names—those are often the hardest places to detect spelling errors. Instead look for places where city names or states aren't consistent. (`Los Angelos` is one very common mistake.) If you find those, you can be pretty sure the data was compiled or edited by hand and that is always a reason to be skeptical of it. Data that has been edited by hand is the most likely to have mistakes. This doesn't mean you shouldn't use it but you may need to manually correct those mistakes or otherwise account for them in your reporting.
 
 See also:
 
@@ -134,13 +134,13 @@ Bad categories can also artificially exclude data. This frequently happens with 
 
 ### Field names are ambiguous
 
-What is a `residence`? Is it where someone lives or where they pay taxes? Is it it a city or a county? Field names in data are never as specific as we would like, but particular concern should be applied to those that could obviously mean two or more things. Even if you correctly infer what the values are supposed to mean, that ambiguity could have easily caused the person collecting the data to enter the wrong value.
+What is a `residence`? Is it where someone lives or where they pay taxes? Is it a city or a county? Field names in data are never as specific as we would like, but particular concern should be applied to those that could obviously mean two or more things. Even if you correctly infer what the values are supposed to mean, that ambiguity could easily have caused the person collecting the data to enter the wrong value.
 
 ### Provenance is not documented
 
-Data can are made by a variety of kinds of individuals and organizations including businesses, governments, nonprofits and nut-job conspiracy theorists. That data can be gathered in many different ways including surveys, sensors and satellites. It may be typed, tapped or scribbled. Knowing where your data came from can give you a huge amount of insight into its limitations.
+Data can be made by a variety of kinds of individuals and organizations including businesses, governments, nonprofits and nut-job conspiracy theorists. That data can be gathered in many different ways including surveys, sensors and satellites. It may be typed, tapped or scribbled. Knowing where your data came from can give you a huge amount of insight into its limitations.
 
-Survey data, for example, is rarely exhaustive. Sensors vary in their accuracy. Governments are often disinclined to give you unbiased information. Data from a war zone may have a strong geographical bias due to the dangers of crossing battle lines. To make this situation worse, these different sources are often daisy-chained together. Academics sometimes redistribute data they got from the government. Data that is written by a doctor may be rekeyed by a nurse. Every stage in that chain is an opportunity for error. Know where your data came from.
+Survey data, for example, is rarely exhaustive. Sensors vary in their accuracy. Governments are often disinclined to give you unbiased information. Data from a war zone may have a strong geographical bias due to the dangers of crossing battle lines. To make this situation worse, these different sources are often daisy-chained together. Academics sometimes redistribute data they got from the government. Data that is written by a doctor may be rekeyed by a nurse. Every link in that chain is an opportunity for error. Know where your data came from.
 
 See also:
 
@@ -156,7 +156,7 @@ If you see any of these numbers in your data, treat them with an abundance of ca
 * [555-3485](https://en.wikipedia.org/wiki/555_%28telephone_number%29)
 * 99999
 
-Each of these numbers has an indication of a particular error made by either a human or a computer. If you see them, ensure they actually mean what you think they mean!
+Each of these numbers has an indication of a particular error made either by a human or a computer. If you see them, ensure they actually mean what you think they mean!
 
 See also:
 
@@ -167,7 +167,7 @@ See also:
 
 You've got states and you need counties. You've got employers and you need employees. They gave you years, but you want months. In many cases we get data that has been aggregated too much for our purposes.
 
-Data can not be disaggregated once it's been put together. If you're given data that's too coarse, you'll need to ask your source for something more specific. They may not have it. If they do have it they may not be able or willing to give it to you. There are many federal datasets that can't be accessed at the local level to protect the privacy of individuals who might be uniquely identified by them. (For example, a single Somali national living in western Texas.) All you can do is ask.
+Data cannot be disaggregated once it's been put together. If you're given data that's too coarse, you'll need to ask your source for something more specific. They may not have it. If they do have it they may not be able or willing to give it to you. There are many federal datasets that can't be accessed at the local level to protect the privacy of individuals who might be uniquely identified by them. (For example, a single Somali national living in western Texas.) All you can do is ask.
 
 One thing you should never ever do is divide the yearly data you have by 12 and call it the "average per month". That is **always** incorrect. Don't do it.
 
@@ -178,9 +178,9 @@ See also:
 
 ### Totals differ from published aggregates
 
-Imagine that after a long FOIA fight you receive a "complete" list of incidents of police use-of-force. You open it up and discover it has 2,467 rows. Great, time to report it out. Not so fast. Before you publish anything from that dataset go find the last time that police chief went on the record about his department's use of force. You may find that in an interview six weeks earlier he said "less than 2,000 times" or that he named a specific number and it doesn't match your dataset.
+Imagine that after a long FOIA fight you receive a "complete" list of incidents of police use-of-force. You open it up and discover it has 2,467 rows. Great, time to report it out. Not so fast. Before you publish anything from that dataset, go find the last time that police chief went on the record about his department's use of force. You may find that in an interview six weeks earlier he said "less than 2,000 times" or that he named a specific number and it doesn't match your dataset.
 
-These sorts of discrepancies between published statistics and raw data can be a very great source of leads. Often times the answer will be simple. For instance, the data you were given may not cover the same time period he was speaking about. But sometimes you'll catch them in a lie. Either way, you should make sure the published numbers match the totals for the data you're given.
+These sorts of discrepancies between published statistics and raw data can be a very great source of leads. Oftentimes the answer will be simple. For instance, the data you were given may not cover the same time period he was speaking about. But sometimes you'll catch them in a lie. Either way, you should make sure the published numbers match the totals for the data you're given.
 
 ### Spreadsheet has 65536 rows
 
@@ -204,7 +204,7 @@ In the vast majority of cases your text editor or spreadsheet application will f
 
 ### Data are in a PDF
 
-A tremendous amount of data—especially government data—is only available in PDF format. If you have real, textual data inside the PDF then there are several good options for extracting it. (If you've got [scanned documents](#data-are-in-scanned-documents) that's a different problem.) One excellent, free tool is [Tabula](#http://tabula.technology/). However, if you have Adobe Creative Cloud then also have access to Acrobat Pro, which has an excellent feature for exporting tables in PDFs to Excel. Either solution should be able to extract most tabular data from a PDF.
+A tremendous amount of data—especially government data—is only available in PDF format. If you have real, textual data inside the PDF then there are several good options for extracting it. (If you've got [scanned documents](#data-are-in-scanned-documents) that's a different problem.) One excellent, free tool is [Tabula](#http://tabula.technology/). However, if you have Adobe Creative Cloud then you also have access to Acrobat Pro, which has an excellent feature for exporting tables in PDFs to Excel. Either solution should be able to extract most tabular data from a PDF.
 
 See also:
 


### PR DESCRIPTION
I like the idea here but am put off by the writing.  If I were a journalist - someone whose job depends on professional-quality writing - and I were handed this, I'd stop taking it seriously at the "anytime" with no space in line 76.  This pull request contains my suggestions for improving it, mostly focused on basic copyediting.  I hope you find them useful.  Here are some more thoughts for which I haven't suggested specific edits, but which might be of interest:

* Decide whether "data" is a singular or plural word.  The current text is inconsistent on this point.  Formally correct traditional usage is that you have one datum (singular), and two data (plural).  But you clearly don't intend to write this document at that level of formality (for instance, you're constantly addressing the reader as "you") and so the plural "data" comes across as forced, especially because it's inconsistent.  Common usage in the tech trade is to treat "data" as uncountable, with singular verb forms:  some data and more data, like some water and more water.  Then one would say "a piece of data" or "an item of data" or a more specific term like "record" if they mean what would traditionally be called a "datum".  The uncountable usage is the one I prefer.

* Oxford comma - that is the one before the "and" in "X, Y, and Z".  You seem not to be using it, and if the audience is American journalists who traditionally don't use it, then leaving it out may be the right decision.  But you should think about this, because failing to include it makes you look uneducated to anyone who cares and isn't an American journalist.

* You sometimes use an ASCII hyphen with no spaces around it as a punctuation dash, as in "I was walking down the street-innocently chewing my bubblegum-when I saw the desperados running out of the convenience store."  In typesetting, this mark ought to be either an em dash (quite a lot longer than a hyphen) with no space around it, or an en dash (somewhat longer than a hyphen but not so long as an em dash) with space around it, depending on whether you want to use the American or British tradition.  I don't know what the right way to express either of these in Markdown should be but it's hard to believe that a single ASCII hyphen with no spaces is right.  When I'm writing pure ASCII I prefer a single ASCII hyphen with spaces before and after.

* Starting a sentence with "this" and not saying "this *what*" is weak; it comes across as "I really wanted to continue the previous sentence but it was getting too long."  There are many instances of this usage in the document.  Better to put a noun after the "this" to make clear what you're talking about without forcing a reference back into the previous sentence.

* At one point you refer to "the crime of 'rape'".  Many people's brains automatically switch off when they read that word; for various sociological reasons rape is subject matter about which rational thought is not allowed.  This effect will detract from the reader's ability to comprehend what you're saying, for at least some readers.  If you can make your point in this paragraph using some other example, that might be better.  I think you mean to be talking about statistics in general, not only rape in particular, and there are many other statistics that similarly depend on the precise definition.

* You write "One thing you should never ever do is divide the yearly data you have by 12 and call it the "average per month". That is **always** incorrect."  The statement is false.  The average *is* by definition the total divided by the sample size.  It's not clear to me what you really mean here. Maybe that average per month *should not be used* because nearly everything that can be measured per year has important seasonal variations?  If you're going to make an absolute "**always**" declaration like this, and you think it's so important that it deserves to be *the only  use of bold in the entire body of the document (!)*, then it's important enough that you should say *why* you think it's true.  Otherwise not only that point comes across as weak, but you come across as someone who makes sweeping, absolute, and not actually true, statements without support; and then other statements you make will also be disbelieved.

* You refer to "the unreflective usage of numbers with very large margins-of-error."  Unreflective means not shiny.  I don't think that's the best word to use here.

* "I" and "we" - you're clearly aiming at a lower formality level than I normally use, and that's okay in itself, but the chatty "I"-statements toward the end may be going a little too far, especially because it's not at all clear who is speaking.  If you want to do that, maybe you should establish your personal connection to the text and the reader by introducing yourself in more detail right at the start; as it is, the first "I"-statement is in the dog-license anecdote two thirds of the way through the document, and especially in that kind of personal context, it comes across as a jarring change in style compared to what was before.