### PR TITLE
Refactor the "Data was entered by humans" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ See also:
 
 ### Data was entered by humans
 
-Human data entry is such a common problem that symptoms of it are mentioned in at least 10 of the other issues described here. There is no worse way to screw up data than to let a single human type it in. For example, I once acquired the complete dog licensing database for Cook County, Illinois. Instead of requiring the person registering their dog to choose a breed from a list, the creators of the system had simply given them a text field to type into. As a result this database contained at least 250 spellings of `Chihuahua`. Even with the best tools available, data this messy can't be saved. It is effectively meaningless. It's not that important with dog data, but you don't want it happening with wounded soldiers or stock tickers. Beware human-entered data.
+Human data entry is a common problem; it is mentioned in at least 10 of the other issues described here. As the number of people entering data increases, the worse this tends to become. For example, I once acquired the complete dog licensing database for Cook County, Illinois. Instead of requiring the person registering their dog to choose a breed from a list, the creators of the system had simply given them a text field to type into. As a result this database contained at least 250 spellings of `Chihuahua`. Beware human-entered data.
 
 ### Data is intermingled with formatting and annotations
 


### PR DESCRIPTION
This paragraph is now shorter and less circuitous.

Original version claimed "There is no worse way to screw up data than to let a single human type it in".  This is false.  Data variability increases significantly with the number of people entering data in free form fields.  The dog-breed example provided says so.

Also the claim that "Even with the best tools available, data this messy can't be saved" is overblown.  The example, as described, isn't difficult since the data domain (dog breeds) is finite.

It might take time and effort, but finite domain data cleansing is rarely impossible.  It depends, and it's not proper to generalize so dramatically here.

So this new version is softer.